### PR TITLE
<path> can be self closing in inline svg

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -371,7 +371,7 @@ var uglifyJS = require('uglify-js');
     }
 
     function isEmptyTag(tag) {
-        return /^(?:area|base|basefont|br|col|frame|hr|img|input|isindex|link|meta|param|embed)$/.test(tag);
+        return /^(?:path|area|base|basefont|br|col|frame|hr|img|input|isindex|link|meta|param|embed)$/.test(tag);
     }
 
     if (global.HTMLParser) {


### PR DESCRIPTION
self closed path tag was modifyed in a wrong way resulting in unclosed path tags
i didnt have time to check all svg tags so this may be a first hint for others