### PR TITLE
Move nodeunit to a dev dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "clean-css": "~3.4.12",
     "uglify-js": "~2.6.2",
     "commander": "~2.9.0",
-    "iconv-lite": "~0.4.13",
+    "iconv-lite": "~0.4.13"
+  },
+  "devDependencies": {
     "nodeunit": "~0.9.1"
   }
 }


### PR DESCRIPTION
(nodeunit is 30MB, making this library substantially larger)
